### PR TITLE
Fix cisco ipv6 neighbors

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_ipv6_neighbors.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_ipv6_neighbors.textfsm
@@ -1,6 +1,6 @@
 Value ADDRESS (\S+)
-Value AGE (\d+)
-Value MAC (\S+)
+Value AGE (\d+|-)
+Value MAC (\S+|-)
 Value TYPE (\S+)
 Value INTERFACE (\S+)
 

--- a/tests/cisco_ios/show_ipv6_neighbors/cisco_ios_show_ipv6_neighbors1.raw
+++ b/tests/cisco_ios/show_ipv6_neighbors/cisco_ios_show_ipv6_neighbors1.raw
@@ -8,3 +8,4 @@ FE80::5AAC:78FF:FEF8:CCCC                  23 58ac.78f8.cccc  STALE Vl6
 FE80::7A0C:F0FF:FE8E:2FF4                 103 780c.f08e.2ff4  STALE Vl6
 FE80::7EAD:74FF:FE85:B86                   22 7cad.7485.0c16  STALE Vl6
 FE80::208:E3FF:FEFF:FC28                    0 0008.e3ff.fc28  REACH Vl687
+FE80::9277:EEFF:FE9B:4E00                   - -               REACH Di0

--- a/tests/cisco_ios/show_ipv6_neighbors/cisco_ios_show_ipv6_neighbors1.yml
+++ b/tests/cisco_ios/show_ipv6_neighbors/cisco_ios_show_ipv6_neighbors1.yml
@@ -45,3 +45,8 @@ parsed_sample:
     interface: "Vl687"
     mac: "0008.e3ff.fc28"
     type: "REACH"
+  - address: "FE80::9277:EEFF:FE9B:4E00"
+    age: "-"
+    interface: "Di0"
+    mac: "-"
+    type: "REACH"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
cisco_ios_show_ipv6_neighbors1, ios, show ipv6 neighbors

##### SUMMARY
The management of dashes for the age and the link-layer was missing for cisco ipv6 neighbors